### PR TITLE
fix: yaml stdout_callback module deprecated and community.general needed

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,7 +9,6 @@ host_key_checking = False
 interpreter_python = auto
 log_path = logs/tdp.log
 hash_behaviour = merge
-stdout_callback = yaml
 
 [inventory]
 cache = true


### PR DESCRIPTION
removed the yaml `stdout_callback` module for two reasons:
- You need the `community.general` Ansible Galaxy collections which will we ask to download after the creation and provisionning of the VM from the `tdp-dev` container.
-  It is deprecated and if not set ansible prints in json format instead of yaml.